### PR TITLE
Typos fix

### DIFF
--- a/apiauth/backend/metamask/serializers.py
+++ b/apiauth/backend/metamask/serializers.py
@@ -79,7 +79,7 @@ class WalletTokenObtainSerializer(serializers.Serializer):
         return cls.token_class.for_user(user)
 
 
-## Same as TokaneObtainPairSerializer from simple-jwt but diffrent base class
+## Same as TokaneObtainPairSerializer from simple-jwt but different base class
 class TokenObtainPairSerializer(WalletTokenObtainSerializer):
     token_class = RefreshToken
 

--- a/apiauth/backend/metamask/serializers.py
+++ b/apiauth/backend/metamask/serializers.py
@@ -46,7 +46,7 @@ class WalletAuthSerializer(serializers.ModelSerializer):
         extra_kwargs = {"user": {"wite_only": True}}
 
 
-## Same as TokenObtainSerializer with a diffrent validation function
+## Same as TokenObtainSerializer with a different validation function
 ## Tech dept: make signature field dynamicaly from settings
 class WalletTokenObtainSerializer(serializers.Serializer):
     token_class = None

--- a/apiauth/backend/metamask/serializers.py
+++ b/apiauth/backend/metamask/serializers.py
@@ -47,7 +47,7 @@ class WalletAuthSerializer(serializers.ModelSerializer):
 
 
 ## Same as TokenObtainSerializer with a different validation function
-## Tech dept: make signature field dynamicaly from settings
+## Tech dept: make signature field dynamically from settings
 class WalletTokenObtainSerializer(serializers.Serializer):
     token_class = None
     signature = serializers.CharField(max_length=200)


### PR DESCRIPTION
Fix: Typos in Comments Corrected

What Changed
Fixed typographical errors in comments to improve clarity and professionalism.

Why These Changes Were Made
Correcting typos enhances the readability and clarity of the codebase, ensuring a more polished and professional appearance.

Additional Notes
These changes are limited to comments only and do not impact the code's functionality